### PR TITLE
fix setting of props['versionBus'] for buses and mediators

### DIFF
--- a/generators/bus/index.js
+++ b/generators/bus/index.js
@@ -80,7 +80,7 @@ module.exports = class extends Generator {
     var self = this;
     var basePath = this.destinationRoot().endsWith('packages') ? './' : './packages/';
 
-    populateProps(self.props, basePath, self.options.namespace);
+    populateProps(self.props, basePath);
     files.forEach(function(file) {
       var s = typeof file == 'string' ? file : file.src,
           d = typeof file == 'string' ? file : file.dest;

--- a/generators/bus/index.js
+++ b/generators/bus/index.js
@@ -80,7 +80,7 @@ module.exports = class extends Generator {
     var self = this;
     var basePath = this.destinationRoot().endsWith('packages') ? './' : './packages/';
 
-    populateProps(self.props, basePath);
+    populateProps(self.props, basePath, self.options.namespace);
     files.forEach(function(file) {
       var s = typeof file == 'string' ? file : file.src,
           d = typeof file == 'string' ? file : file.dest;

--- a/generators/common/props.js
+++ b/generators/common/props.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 
-function populateProps(props, basePath, namespace) {
+function populateProps(props, basePath) {
   var cwd = process.cwd() + '/';
   var requirePath = cwd + basePath + '../node_modules/@comunica/';
   props['versionComunicaCore'] = require(requirePath + 'core/package.json').version;

--- a/generators/common/props.js
+++ b/generators/common/props.js
@@ -4,10 +4,8 @@ function populateProps(props, basePath, namespace) {
   var cwd = process.cwd() + '/';
   var requirePath = cwd + basePath + '../node_modules/@comunica/';
   props['versionComunicaCore'] = require(requirePath + 'core/package.json').version;
-  if (namespace === "comunica:actor") {
+  if (props.busName) {
     props['versionBus'] = require(requirePath + 'bus-' + props.busName + '/package.json').version;
-  } else {
-    props['versionBus'] = props['versionComunicaCore']
   }
 }
 

--- a/generators/common/props.js
+++ b/generators/common/props.js
@@ -1,10 +1,14 @@
 var fs = require('fs');
 
-function populateProps(props, basePath) {
+function populateProps(props, basePath, namespace) {
   var cwd = process.cwd() + '/';
   var requirePath = cwd + basePath + '../node_modules/@comunica/';
   props['versionComunicaCore'] = require(requirePath + 'core/package.json').version;
-  props['versionBus'] = require(requirePath + 'bus-' + props.busName + '/package.json').version;
+  if (namespace === "comunica:actor") {
+    props['versionBus'] = require(requirePath + 'bus-' + props.busName + '/package.json').version;
+  } else {
+    props['versionBus'] = props['versionComunicaCore']
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
When trying to generate a new bus I received the following error
```
Error: Cannot find module '/home/jesse/gh/comunica/packages/./../node_modules/@comunica/bus-undefined/package.json'
```
I think this is because it is trying to get the version of the bus https://github.com/comunica/generate-comunica/blob/ca1d7a2c9aacf6d886f1be21d2be1b5531bc92ef/generators/common/props.js#L7 which has not yet been created.

This PR resolves that by setting `props['versionBus'] = props['versionComunicaCore']` when we are not creating an actor.

Because this package does not have any tests - the only thing I can verify is that with this fix a bus is correctly generated on my Linux machine. 