### PR TITLE
Replace the use of npm with yarn in templates

### DIFF
--- a/generators/actor-query-operation/templates/package.json
+++ b/generators/actor-query-operation/templates/package.json
@@ -36,7 +36,7 @@
     "@comunica/bus-query-operation": "^<%= versionBus %>"
   },
   "scripts": {
-    "build": "npm run build:ts && npm run build:components",
+    "build": "yarn run build:ts && yarn run build:components",
     "build:ts": "node \"../../node_modules/typescript/bin/tsc\"",
     "build:components": "componentsjs-generator"
   }

--- a/generators/actor/templates/package.json
+++ b/generators/actor/templates/package.json
@@ -36,7 +36,7 @@
     "@comunica/bus-<%= busName %>": "^<%= versionBus %>"
   },
   "scripts": {
-    "build": "npm run build:ts && npm run build:components",
+    "build": "yarn run build:ts && yarn run build:components",
     "build:ts": "node \"../../node_modules/typescript/bin/tsc\"",
     "build:components": "componentsjs-generator"
   }

--- a/generators/bus/templates/package.json
+++ b/generators/bus/templates/package.json
@@ -34,7 +34,7 @@
     "@comunica/core": "^<%= versionComunicaCore %>"
   },
   "scripts": {
-    "build": "npm run build:ts && npm run build:components",
+    "build": "yarn run build:ts && yarn run build:components",
     "build:ts": "node \"../../node_modules/typescript/bin/tsc\"",
     "build:components": "componentsjs-generator"
   }

--- a/generators/mediator/templates/package.json
+++ b/generators/mediator/templates/package.json
@@ -32,7 +32,7 @@
     "@comunica/core": "^<%= versionComunicaCore %>"
   },
   "scripts": {
-    "build": "npm run build:ts && npm run build:components",
+    "build": "yarn run build:ts && yarn run build:components",
     "build:ts": "node \"../../node_modules/typescript/bin/tsc\"",
     "build:components": "componentsjs-generator"
   }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Generators for Comunica modules",
   "main": "index.js",
+  "packageManager": "yarn@1.22.22",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Here is a small set of changes to replace `npm` with `yarn` in the template package.json scripts. I decided not to spend time changing anything else, as those seemed to be the only places where `npm` was referenced.

Edit: also, the `packageManager` field is now in the main package.json.